### PR TITLE
correcting error in DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -12,38 +12,38 @@
 	],
 	"creators": [
 		{
-            "fullName": "Xian Wan",
-            "firstName": "Xian",
-            "lastName": "Wan",
-            "affiliations": [
-                {
-                    "name": "Department of Psychiatry and Bioinformatics Centre, UBC"
-                }
-            ]
+			"fullName": "Xian Wan",
+			"firstName": "Xian",
+			"lastName": "Wan",
+			"affiliations": [
+				{
+					"name": "Department of Psychiatry and Bioinformatics Centre, UBC"
+				}
+			]
 		},
-	{
-		"name": "Tomi Pastinen",
-		"roles": [
-			{
-				"value": "Principal Investigator"
-			}
-		],
-		"affiliations": [
-			{
-				"name": "McGill University"
-			}
-		]
-	},
-        {
-            "fullName": "Paul Pavlidis",
-            "firstName": "Paul",
-            "lastName": "Pavlidis",
-            "affiliations": [
-                {
-                    "name": "Department of Psychiatry and Bioinformatics Centre, UBC"
-                }
-            ]
-        }
+		{
+			"fullName": "Tomi Pastinen",
+			"roles": [
+				{
+					"value": "Principal Investigator"
+				}
+			],
+			"affiliations": [
+				{
+					"name": "McGill University"
+				}
+			]
+		},
+        	{
+			"fullName": "Paul Pavlidis",
+			"firstName": "Paul",
+			"lastName": "Pavlidis",
+			"affiliations": [
+				{
+					"name": "Department of Psychiatry and Bioinformatics Centre, UBC"
+				}
+			]
+        	}
 	],
 	"types": [
 		{


### PR DESCRIPTION
This PR corrects an error in DATS.json introduced in https://github.com/gi114/Reusing-Neuro-Data/pull/1 and reformats the `creators` entry for legibility.